### PR TITLE
fix: allowing 117 overrides now works correctly

### DIFF
--- a/src/main/java/com/weather3d/CyclesConfig.java
+++ b/src/main/java/com/weather3d/CyclesConfig.java
@@ -20,6 +20,7 @@ public interface CyclesConfig extends Config {
 
 	enum SeasonType {
 		DYNAMIC,
+		HD_117,
 		SPRING,
 		SUMMER,
 		AUTUMN,
@@ -359,24 +360,5 @@ public interface CyclesConfig extends Config {
 	default boolean enableLightning()
 	{
 		return false;
-	}
-
-	@ConfigSection(
-			name = "Other",
-			description = "Other Settings",
-			position = 28
-	)
-	String otherSettings = "otherSettings";
-
-	@ConfigItem(
-			keyName = "117Themes",
-			name = "Allow 117 Theme Overrides",
-			description = "Allows 117HD to override current Season with its relevant seasonal theme",
-			section = otherSettings,
-			position = 29
-	)
-	default boolean themes117()
-	{
-		return true;
 	}
 }


### PR DESCRIPTION
### Changes

- the base functionality will no longer overwrite the 117 HD Seasons
- added support for 117's automatic mode
- corrected the expected `seasonalTheme` values from 117 HD

### Screenshots

<details> 
  <summary>Automatic</summary>

  **Before**

   ![image](https://github.com/ScreteMonge/3D-Weather/assets/9692284/02ae119f-bdc6-4cb6-b976-dda90c711f79)

  **After**

  ![image](https://github.com/ScreteMonge/3D-Weather/assets/9692284/24e36b74-e25f-4f17-9558-60afb5431146)

</details>

<details> 
  <summary>Summer</summary>

  **Before**

  ![image](https://github.com/ScreteMonge/3D-Weather/assets/9692284/7257ad89-2322-4067-95da-0e8800220ce1)

  **After**

  ![image](https://github.com/ScreteMonge/3D-Weather/assets/9692284/c54304d0-e59f-489f-9b7e-6f22deb74b65)
</details>

<details> 
  <summary>Autumn</summary>

  **Before**

  ![image](https://github.com/ScreteMonge/3D-Weather/assets/9692284/21f161ec-4de0-4b7a-a47b-2f1ef4660b43)

  **After**

  ![image](https://github.com/ScreteMonge/3D-Weather/assets/9692284/bdf7ccdf-73a7-4a5a-910b-43468fbd0901)
</details>

<details> 
  <summary>Winter</summary>

  **Before**

  ![image](https://github.com/ScreteMonge/3D-Weather/assets/9692284/04cfb9c1-f00d-483f-93f9-f09f1997f079)

  **After**

  ![image](https://github.com/ScreteMonge/3D-Weather/assets/9692284/397849a6-30c2-4b3e-ae30-cd06097fc263)
</details>